### PR TITLE
Remove all type specific functions in favor of generic core

### DIFF
--- a/examples/core.lisp
+++ b/examples/core.lisp
@@ -6,9 +6,14 @@
 (def empty? (fn* empty? [coll]
     (if (nil? coll)
         true
-        (if (not (seq? coll))
-            (throw "argument must be a sequence")
-            (nil? (first coll))))))
+        (nil? (first coll)))))
+
+(def true? (fn* true? [arg]
+    (if (nil? arg)
+        false
+        (if (boolean? arg)
+            arg
+            true))))
 
 (def not (fn* not [arg]
     (= false (true? arg))))
@@ -16,6 +21,7 @@
 (def same-type? (fn* same-type? [a b] (= (type a) (type b))))
 
 ; Type check functions
+(def seq? (fn* seq? [arg] (impl? arg types/Seq)))
 (def set? (fn* set? [s] (same-type? #{} s)))
 (def list? (fn* list? [s] (same-type? () s)))
 (def vector? (fn* vector? [s] (same-type? [] s)))

--- a/examples/core.lisp
+++ b/examples/core.lisp
@@ -1,0 +1,36 @@
+(ns 'core)
+
+(def nil? (fn* nil? [arg]
+    (= nil arg)))
+
+(def empty? (fn* empty? [coll]
+    (if (nil? coll)
+        true
+        (if (not (seq? coll))
+            (throw "argument must be a sequence")
+            (nil? (first coll))))))
+
+(def not (fn* not [arg]
+    (= false (true? arg))))
+
+(def same-type? (fn* same-type? [a b] (= (type a) (type b))))
+
+; Type check functions
+(def set? (fn* set? [s] (same-type? #{} s)))
+(def list? (fn* list? [s] (same-type? () s)))
+(def vector? (fn* vector? [s] (same-type? [] s)))
+(def int? (fn* int? [arg] (same-type? 0 arg)))
+(def float? (fn* float? [arg] (same-type? 0.0 arg)))
+(def boolean? (fn* boolean? [arg] (same-type? true arg)))
+(def string? (fn* string? [arg] (same-type? "" arg)))
+(def keyword? (fn* keyword? [arg] (same-type? :keyword arg)))
+(def symbol? (fn* symbol? [arg] (same-type? 'sample arg)))
+
+; Type initialization functions
+(def set (fn* set [s] (apply-seq (type #{}) s)))
+(def list (fn* list [& args] (realize args)))
+(def vector (fn* list [& args] (realize args)))
+
+(def int (fn* int [arg] (to-type arg (type 0))))
+(def float (fn* float [arg] (to-type arg (type 0.0))))
+(def boolean (fn* boolean [arg] (true? arg)))

--- a/examples/slang_test.go
+++ b/examples/slang_test.go
@@ -1,1 +1,0 @@
-package examples

--- a/reflect.go
+++ b/reflect.go
@@ -3,7 +3,10 @@ package sabre
 import (
 	"fmt"
 	"reflect"
+	"strings"
 )
+
+var scopeType = reflect.TypeOf((*Scope)(nil)).Elem()
 
 // ValueOf converts a Go value to sabre Value type. Functions will be
 // converted to the Func type. Other primitive Go types like string, rune,
@@ -46,19 +49,19 @@ func ValueOf(v interface{}) Value {
 
 	default:
 		// TODO: handle array & slice as list/vector.
-		return anyValue{rv: rv}
+		return Any{R: rv}
 	}
 }
 
-type anyValue struct{ rv reflect.Value }
-
-func (any anyValue) Eval(_ Scope) (Value, error) {
-	return any, nil
+// Any can be used to wrap arbitrary Go value into Sabre scope.
+type Any struct {
+	R reflect.Value
 }
 
-func (any anyValue) String() string {
-	return fmt.Sprintf("Any{%v}", any.rv)
-}
+// Eval returns itself.
+func (any Any) Eval(_ Scope) (Value, error) { return any, nil }
+
+func (any Any) String() string { return fmt.Sprintf("Any{%v}", any.R) }
 
 // Type represents the type value of a given value. Type also implements
 // Value type.
@@ -100,142 +103,205 @@ func (t Type) Invoke(scope Scope, args ...Value) (Value, error) {
 	return ValueOf(reflect.New(t.rt).Elem().Interface()), nil
 }
 
-func reflectFn(rv reflect.Value) Fn {
-	fn := Fn{}
+// reflectFn creates a wrapper Fn for the given Go function value using
+// reflection.
+func reflectFn(rv reflect.Value) *Fn {
+	fw := wrapFunc(rv)
 
-	fn.Func = func(scope Scope, args []Value) (_ Value, err error) {
-		defer func() {
-			if v := recover(); v != nil {
-				if e, ok := v.(error); ok {
-					err = e
-				} else {
-					err = fmt.Errorf("panic: %v", v)
-				}
-			}
-		}()
-
-		args, err = evalValueList(scope, args)
-		if err != nil {
-			return nil, err
-		}
-
-		rt := rv.Type()
-		argVals := reflectValues(args)
-
-		if minArgs(rt) > 0 {
-			scopeRV := reflect.ValueOf(scope)
-			if scopeRV.Type().AssignableTo(rt.In(0)) {
-				argVals = append([]reflect.Value{scopeRV}, argVals...)
-			}
-		}
-
-		if err := checkArgCount(rt, len(argVals)); err != nil {
-			return nil, err
-		}
-
-		converted, err := convertArgTypes(rt, argVals)
-		if err != nil {
-			return nil, err
-		}
-
-		retVals := rv.Call(converted)
-		return wrapReturnValues(rt, retVals)
+	cleanArgName := func(t reflect.Type) string {
+		return strings.Replace(t.String(), "sabre.", "", -1)
 	}
 
-	return fn
+	var argNames []string
+
+	i := 0
+	for ; i < fw.minArgs; i++ {
+		argNames = append(argNames, cleanArgName(fw.rt.In(i)))
+	}
+	if fw.rt.IsVariadic() {
+		argNames = append(argNames, cleanArgName(fw.rt.In(i).Elem()))
+	}
+
+	fn := Fn{
+		Args:     argNames,
+		Variadic: rv.Type().IsVariadic(),
+		Func: func(scope Scope, args []Value) (_ Value, err error) {
+			defer func() {
+				if v := recover(); v != nil {
+					err = fmt.Errorf("panic: %v", v)
+				}
+			}()
+
+			args, err = evalValueList(scope, args)
+			if err != nil {
+				return nil, err
+			}
+
+			return fw.Call(scope, args...)
+		},
+	}
+
+	return &fn
 }
 
-func wrapReturnValues(fn reflect.Type, vals []reflect.Value) (Value, error) {
-	if fn.NumOut() == 0 {
+func wrapFunc(rv reflect.Value) *funcWrapper {
+	rt := rv.Type()
+
+	minArgs := rt.NumIn()
+	if rt.IsVariadic() {
+		minArgs = minArgs - 1
+	}
+
+	passScope := (minArgs > 0) && (rt.In(0) == scopeType)
+	lastOutIdx := rt.NumOut() - 1
+	returnsErr := lastOutIdx >= 0 && rt.Out(lastOutIdx).Name() == "error"
+	if returnsErr {
+		lastOutIdx-- // ignore error value from return values
+	}
+
+	return &funcWrapper{
+		rv:         rv,
+		rt:         rt,
+		minArgs:    minArgs,
+		passScope:  passScope,
+		returnsErr: returnsErr,
+		lastOutIdx: lastOutIdx,
+	}
+}
+
+type funcWrapper struct {
+	rv         reflect.Value
+	rt         reflect.Type
+	passScope  bool
+	minArgs    int
+	returnsErr bool
+	lastOutIdx int
+}
+
+func (fw *funcWrapper) Call(scope Scope, vals ...Value) (Value, error) {
+	args := reflectValues(vals)
+	if fw.passScope {
+		args = append([]reflect.Value{reflect.ValueOf(scope)}, args...)
+	}
+
+	if err := fw.checkArgCount(len(args)); err != nil {
+		return nil, err
+	}
+
+	args, err := fw.convertTypes(args...)
+	if err != nil {
+		return nil, err
+	}
+
+	return fw.wrapReturns(fw.rv.Call(args)...)
+}
+
+func (fw *funcWrapper) convertTypes(args ...reflect.Value) ([]reflect.Value, error) {
+	var vals []reflect.Value
+
+	for i := 0; i < fw.rt.NumIn(); i++ {
+		if fw.rt.IsVariadic() && i == fw.rt.NumIn()-1 {
+			c, err := convertArgsTo(fw.rt.In(i).Elem(), args[i:]...)
+			if err != nil {
+				return nil, err
+			}
+			vals = append(vals, c...)
+			break
+		}
+
+		c, err := convertArgsTo(fw.rt.In(i), args[i])
+		if err != nil {
+			return nil, err
+		}
+		vals = append(vals, c...)
+	}
+
+	return vals, nil
+}
+
+func (fw *funcWrapper) checkArgCount(count int) error {
+	if count != fw.minArgs {
+		if fw.rt.IsVariadic() && count < fw.minArgs {
+			return fmt.Errorf(
+				"call requires at-least %d argument(s), got %d",
+				fw.minArgs, count,
+			)
+		} else if !fw.rt.IsVariadic() && count > fw.minArgs {
+			return fmt.Errorf(
+				"call requires exactly %d argument(s), got %d",
+				fw.minArgs, count,
+			)
+		}
+	}
+
+	return nil
+}
+
+func (fw *funcWrapper) wrapReturns(vals ...reflect.Value) (Value, error) {
+	if fw.rt.NumOut() == 0 {
 		return Nil{}, nil
 	}
 
-	lastArgIdx := fn.NumOut() - 1
-	isLastArgErr := fn.Out(lastArgIdx).Name() == "error"
-
-	if isLastArgErr {
-		if !vals[lastArgIdx].IsNil() {
-			return nil, vals[lastArgIdx].Interface().(error)
+	if fw.returnsErr {
+		errIndex := fw.lastOutIdx + 1
+		if !vals[errIndex].IsNil() {
+			return nil, vals[errIndex].Interface().(error)
 		}
 
-		if fn.NumOut() == 1 {
+		if fw.rt.NumOut() == 1 {
 			return Nil{}, nil
 		}
 	}
 
-	lastValIdx := lastArgIdx + 1
-	if isLastArgErr {
-		lastValIdx = lastValIdx - 1
+	wrapped := sabreValues(vals[0 : fw.lastOutIdx+1])
+	if len(wrapped) == 1 {
+		return wrapped[0], nil
 	}
 
-	var wrappedRetVals []Value
-	for _, retVal := range vals[0:lastValIdx] {
-		wrappedRetVals = append(wrappedRetVals, ValueOf(retVal.Interface()))
-	}
-
-	if len(wrappedRetVals) == 1 {
-		return wrappedRetVals[0], nil
-	}
-
-	return &List{Values: wrappedRetVals}, nil
+	return Values(wrapped), nil
 }
 
-func convertArgTypes(rt reflect.Type, args []reflect.Value) ([]reflect.Value, error) {
-	required := minArgs(rt)
+func convertArgsTo(expected reflect.Type, args ...reflect.Value) ([]reflect.Value, error) {
 	var converted []reflect.Value
+	for _, arg := range args {
+		actual := arg.Type()
+		switch {
+		case isAssignable(actual, expected):
+			converted = append(converted, arg)
 
-	i := 0
-	for ; i < required; i++ {
-		c, err := convertArgType(rt.In(i), args[i])
-		if err != nil {
-			return nil, err
-		}
-		converted = append(converted, c)
-	}
+		case actual.ConvertibleTo(expected):
+			converted = append(converted, arg.Convert(expected))
 
-	if rt.IsVariadic() {
-		expected := rt.In(i).Elem()
-		for ; i < len(args); i++ {
-			c, err := convertArgType(expected, args[i])
-			if err != nil {
-				return nil, err
-			}
-			converted = append(converted, c)
+		default:
+			return args, fmt.Errorf(
+				"value of type '%s' cannot be converted to '%s'",
+				actual, expected,
+			)
 		}
 	}
 
 	return converted, nil
 }
 
-func convertArgType(expected reflect.Type, value reflect.Value) (reflect.Value, error) {
-	actual := value.Type()
-	switch {
-	case actual == expected || actual.AssignableTo(expected):
-		return value, nil
-
-	case (expected.Kind() == reflect.Interface) &&
-		actual.Implements(expected):
-		return value, nil
-
-	case actual.ConvertibleTo(expected):
-		return value.Convert(expected), nil
-
-	}
-
-	return value, fmt.Errorf(
-		"invalid argument type: expected=%s, actual=%s",
-		expected, actual,
-	)
+func isAssignable(from, to reflect.Type) bool {
+	return (from == to) || from.AssignableTo(to) ||
+		(to.Kind() == reflect.Interface && from.Implements(to))
 }
 
 func reflectValues(args []Value) []reflect.Value {
 	var rvs []reflect.Value
-
 	for _, arg := range args {
 		rvs = append(rvs, reflect.ValueOf(arg))
 	}
-
 	return rvs
+}
+
+func sabreValues(rvs []reflect.Value) []Value {
+	var vals []Value
+	for _, arg := range rvs {
+		vals = append(vals, ValueOf(arg.Interface()))
+	}
+	return vals
 }
 
 func isKind(rt reflect.Type, kinds ...reflect.Kind) bool {
@@ -246,34 +312,4 @@ func isKind(rt reflect.Type, kinds ...reflect.Kind) bool {
 	}
 
 	return false
-}
-
-func minArgs(rt reflect.Type) int {
-	if rt.IsVariadic() {
-		return rt.NumIn() - 1
-	}
-
-	return rt.NumIn()
-}
-
-func checkArgCount(rt reflect.Type, argCount int) error {
-	if !rt.IsVariadic() {
-		if argCount != minArgs(rt) {
-			return fmt.Errorf(
-				"call requires exactly %d argument(s), got %d",
-				rt.NumIn(), argCount,
-			)
-		}
-		return nil
-	}
-
-	required := minArgs(rt)
-	if argCount < required {
-		return fmt.Errorf(
-			"call requires at-least %d argument(s), got %d",
-			required, argCount,
-		)
-	}
-
-	return nil
 }

--- a/reflect.go
+++ b/reflect.go
@@ -113,13 +113,8 @@ func (t Type) Invoke(scope Scope, args ...Value) (Value, error) {
 func reflectFn(rv reflect.Value) *Fn {
 	fw := wrapFunc(rv)
 
-	cleanArgName := func(t reflect.Type) string {
-		return strings.Replace(t.String(), "sabre.", "", -1)
-	}
-
-	var argNames []string
-
 	i := 0
+	var argNames []string
 	for ; i < fw.minArgs; i++ {
 		argNames = append(argNames, cleanArgName(fw.rt.In(i)))
 	}
@@ -127,7 +122,7 @@ func reflectFn(rv reflect.Value) *Fn {
 		argNames = append(argNames, cleanArgName(fw.rt.In(i).Elem()))
 	}
 
-	fn := Fn{
+	return &Fn{
 		Args:     argNames,
 		Variadic: rv.Type().IsVariadic(),
 		Func: func(scope Scope, args []Value) (_ Value, err error) {
@@ -145,8 +140,6 @@ func reflectFn(rv reflect.Value) *Fn {
 			return fw.Call(scope, args...)
 		},
 	}
-
-	return &fn
 }
 
 func wrapFunc(rv reflect.Value) *funcWrapper {
@@ -286,6 +279,10 @@ func convertArgsTo(expected reflect.Type, args ...reflect.Value) ([]reflect.Valu
 	}
 
 	return converted, nil
+}
+
+func cleanArgName(t reflect.Type) string {
+	return strings.Replace(t.String(), "sabre.", "", -1)
 }
 
 func isAssignable(from, to reflect.Type) bool {

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -53,7 +53,7 @@ func TestValueOf(t *testing.T) {
 		{
 			name: "Any",
 			v:    anyVal,
-			want: anyValue{rv: anyValRV},
+			want: Any{R: anyValRV},
 		},
 	}
 
@@ -126,7 +126,7 @@ func Test_strictFn_Invoke(t *testing.T) {
 			name: "MultiReturn",
 			v:    func(arg Int64) (int64, string) { return 10, "hello" },
 			args: []Value{Int64(10)},
-			want: &List{Values: []Value{Int64(10), String("hello")}},
+			want: Values([]Value{Int64(10), String("hello")}),
 		},
 		{
 			name:    "NoArgMultiReturnWithError",

--- a/sabre_test.go
+++ b/sabre_test.go
@@ -25,6 +25,16 @@ func BenchmarkEval(b *testing.B) {
 	}
 }
 
+func BenchmarkGoCall(b *testing.B) {
+	inc := func(a int) int {
+		return a + 1
+	}
+
+	for i := 0; i < b.N; i++ {
+		_ = inc(10)
+	}
+}
+
 func TestEval(t *testing.T) {
 	t.Parallel()
 

--- a/slang/slang.go
+++ b/slang/slang.go
@@ -188,12 +188,11 @@ func BindAll(scope sabre.Scope) error {
 		},
 
 		"core/eval":      sabre.ValueOf(sabre.Eval),
-		"core/true?":     sabre.ValueOf(IsTruthy),
 		"core/type":      sabre.ValueOf(TypeOf),
 		"core/to-type":   sabre.ValueOf(ToType),
+		"core/impl?":     sabre.ValueOf(Implements),
 		"core/realize":   sabre.ValueOf(Realize),
 		"core/apply-seq": sabre.ValueOf(ApplySeq),
-		"core/seq?":      sabre.ValueOf(IsSeq),
 
 		// Sequence functions
 		"core/next":  sabre.ValueOf(Next),
@@ -218,6 +217,9 @@ func BindAll(scope sabre.Scope) error {
 		// io functions
 		"core/println": sabre.ValueOf(Println),
 		"core/printf":  sabre.ValueOf(Printf),
+
+		"types/Seq":       TypeOf((*sabre.Seq)(nil)),
+		"types/Invokable": TypeOf((*sabre.Invokable)(nil)),
 	}
 
 	for sym, val := range core {

--- a/slang/slang.go
+++ b/slang/slang.go
@@ -3,7 +3,6 @@ package slang
 import (
 	"fmt"
 	"io"
-	"reflect"
 	"strings"
 	"sync"
 
@@ -187,10 +186,14 @@ func BindAll(scope sabre.Scope) error {
 			Args:     []string{"expr", "err?"},
 			Variadic: true,
 		},
-		"core/eval":   sabre.ValueOf(sabre.Eval),
-		"core/not":    sabre.ValueOf(Not),
-		"core/empty?": sabre.ValueOf(IsEmpty),
-		"core/true?":  sabre.ValueOf(IsTruthy),
+
+		"core/eval":      sabre.ValueOf(sabre.Eval),
+		"core/true?":     sabre.ValueOf(IsTruthy),
+		"core/type":      sabre.ValueOf(TypeOf),
+		"core/to-type":   sabre.ValueOf(ToType),
+		"core/realize":   sabre.ValueOf(Realize),
+		"core/apply-seq": sabre.ValueOf(ApplySeq),
+		"core/seq?":      sabre.ValueOf(IsSeq),
 
 		// Sequence functions
 		"core/next":  sabre.ValueOf(Next),
@@ -199,25 +202,7 @@ func BindAll(scope sabre.Scope) error {
 		"core/conj":  sabre.ValueOf(Conj),
 
 		// Type system functions
-		"core/set":      makeContainer(sabre.Set{}),
-		"core/list":     makeContainer(&sabre.List{}),
-		"core/vector":   makeContainer(sabre.Vector{}),
-		"core/int?":     IsType(reflect.TypeOf(sabre.Int64(0))),
-		"core/set?":     IsType(reflect.TypeOf(sabre.Set{})),
-		"core/boolean?": IsType(reflect.TypeOf(sabre.Bool(false))),
-		"core/list?":    IsType(reflect.TypeOf(&sabre.List{})),
-		"core/string?":  IsType(reflect.TypeOf(sabre.String(""))),
-		"core/float?":   IsType(reflect.TypeOf(sabre.Float64(0))),
-		"core/vector?":  IsType(reflect.TypeOf(sabre.Vector{})),
-		"core/keyword?": IsType(reflect.TypeOf(sabre.Keyword(""))),
-		"core/symbol?":  IsType(reflect.TypeOf(sabre.Symbol{})),
-		"core/nil?":     IsType(reflect.TypeOf(sabre.Nil{})),
-		"core/int":      sabre.ValueOf(MakeInt),
-		"core/float":    sabre.ValueOf(MakeFloat),
-		"core/seq?":     sabre.ValueOf(IsSeq),
-		"core/type":     sabre.ValueOf(TypeOf),
-		"core/boolean":  sabre.ValueOf(MakeBool),
-		"core/str":      sabre.ValueOf(MakeString),
+		"core/str": sabre.ValueOf(MakeString),
 
 		// Math functions
 		"core/+":  sabre.ValueOf(Add),

--- a/slang/slang_test.go
+++ b/slang/slang_test.go
@@ -65,7 +65,7 @@ func TestSlang_Resolve(t *testing.T) {
 	}{
 		{
 			name:   "CoreBinding",
-			symbol: "core/true?",
+			symbol: "core/impl?",
 		},
 		{
 			name:    "UserBinding",

--- a/slang/slang_test.go
+++ b/slang/slang_test.go
@@ -65,7 +65,7 @@ func TestSlang_Resolve(t *testing.T) {
 	}{
 		{
 			name:   "CoreBinding",
-			symbol: "core/not",
+			symbol: "core/true?",
 		},
 		{
 			name:    "UserBinding",
@@ -119,10 +119,28 @@ func testFile(t *testing.T, file string) {
 	}
 	defer fh.Close()
 
-	sl := slang.New()
+	sl, err := initSlang()
+	if err != nil {
+		t.Fatalf("failed to init slang: %v", err)
+	}
 
 	_, err = sl.ReadEval(fh)
 	if err != nil {
 		t.Errorf("execution failed for '%s': %v", file, err)
 	}
+}
+
+func initSlang() (*slang.Slang, error) {
+	fh, err := os.Open(filepath.Join(testDir, "core.lisp"))
+	if err != nil {
+		return nil, err
+	}
+	defer fh.Close()
+
+	sl := slang.New()
+	if _, err := sl.ReadEval(fh); err != nil {
+		return nil, err
+	}
+
+	return sl, nil
 }

--- a/slang/values.go
+++ b/slang/values.go
@@ -1,55 +1,10 @@
 package slang
 
 import (
-	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/spy16/sabre"
 )
-
-// TypeOf returns the type information object for the given argument.
-func TypeOf(val sabre.Value) sabre.Value {
-	return sabre.ValueOf(reflect.TypeOf(val))
-}
-
-// IsType returns a Fn that checks if the value is of given type.
-func IsType(rt reflect.Type) sabre.Value {
-	return sabre.ValueOf(func(val sabre.Value) (sabre.Value, error) {
-		target := reflect.TypeOf(val)
-		return sabre.Bool(target == rt), nil
-	})
-}
-
-// MakeBool converts given argument to a boolean. Any truthy value
-// is converted to true and else false.
-func MakeBool(val sabre.Value) sabre.Bool {
-	return sabre.Bool(IsTruthy(val))
-}
-
-// MakeInt converts given value to integer and returns.
-func MakeInt(val sabre.Value) (sabre.Value, error) {
-	to := reflect.TypeOf(sabre.Int64(0))
-	rv := reflect.ValueOf(val)
-
-	if !rv.Type().ConvertibleTo(to) {
-		return nil, fmt.Errorf("cannot convert '%s' to '%s'", rv.Type(), to)
-	}
-
-	return rv.Convert(to).Interface().(sabre.Int64), nil
-}
-
-// MakeFloat converts given value to float and returns.
-func MakeFloat(val sabre.Value) (sabre.Value, error) {
-	to := reflect.TypeOf(sabre.Float64(0))
-	rv := reflect.ValueOf(val)
-
-	if !rv.Type().ConvertibleTo(to) {
-		return nil, fmt.Errorf("cannot convert '%s' to '%s'", rv.Type(), to)
-	}
-
-	return rv.Convert(to).Interface().(sabre.Float64), nil
-}
 
 // MakeString returns stringified version of all args.
 func MakeString(vals ...sabre.Value) sabre.Value {
@@ -73,76 +28,4 @@ func MakeString(vals ...sabre.Value) sabre.Value {
 		}
 		return sabre.String(sb.String())
 	}
-}
-
-// makeContainer can make a composite type like list, set and vector from
-// given args.
-func makeContainer(targetType sabre.Value) sabre.Value {
-	return sabre.ValueOf(func(args ...sabre.Value) (sabre.Value, error) {
-		switch targetType.(type) {
-		case *sabre.List:
-			return &sabre.List{Values: args}, nil
-
-		case sabre.Vector:
-			return sabre.Vector{Values: args}, nil
-
-		case sabre.Set:
-			if err := verifyArgCount([]int{1}, args); err != nil {
-				return nil, err
-			}
-
-			seq, ok := args[0].(sabre.Seq)
-			if !ok {
-				return nil, fmt.Errorf("can't create seq from '%s'",
-					reflect.TypeOf(args[0]))
-			}
-
-			seqVals := realize(seq)
-
-			return sabre.Set{
-				Values: sabre.Values(seqVals).Uniq(),
-			}, nil
-		}
-
-		return nil, fmt.Errorf("cannot make container of type '%s'", reflect.TypeOf(targetType))
-	})
-}
-
-func realize(seq sabre.Seq) []sabre.Value {
-	var vals []sabre.Value
-
-	for seq != nil {
-		v := seq.First()
-		if v == nil {
-			break
-		}
-
-		vals = append(vals, v)
-		seq = seq.Next()
-	}
-
-	return vals
-}
-
-// Fn implements invokable with simple functions.
-type Fn func(vals []sabre.Value) (sabre.Value, error)
-
-// Eval simply returns the value.
-func (fn Fn) Eval(_ sabre.Scope) (sabre.Value, error) {
-	return fn, nil
-}
-
-func (fn Fn) String() string {
-	return fmt.Sprintf("%s", reflect.ValueOf(fn).Type())
-}
-
-// Invoke evaluates all the args against the scope and dispatches the
-// evaluated list as args to the wrapped function.
-func (fn Fn) Invoke(scope sabre.Scope, args ...sabre.Value) (sabre.Value, error) {
-	vals, err := evalValueList(scope, args)
-	if err != nil {
-		return nil, err
-	}
-
-	return fn(vals)
 }


### PR DESCRIPTION
* Removes all type check functions from Go code (`vector?`, `string?` etc.)
* Adds generic functions like `to-type`, `type` and type invocation for initialization
* Adds `core.lisp` file that defines `vector?`, `string?` etc.