### PR TITLE
Print errors with extended formatting.

### DIFF
--- a/repl/option.go
+++ b/repl/option.go
@@ -96,7 +96,6 @@ func WithReaderFactory(factory ReaderFactory) Option {
 // WithPrinter sets the print function for the REPL.  It is useful for customizing
 // how different types should be rendered into human-readable character streams.
 func WithPrinter(f func(io.Writer, interface{}) error) Option {
-
 	if f == nil {
 		f = func(w io.Writer, v interface{}) (err error) {
 			switch v.(type) {

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -109,7 +109,7 @@ func (repl *REPL) Write(b []byte) (int, error) {
 
 func (repl *REPL) print(res sabre.Value, err error) error {
 	if err != nil {
-		_, err = fmt.Fprintf(repl, "%v\n", err)
+		_, err = fmt.Fprintf(repl, "%+v\n", err)
 		return err
 	}
 


### PR DESCRIPTION
This is useful for printing stack traces from github.com/pkg/errors.