### PR TITLE
Add support for member access using . operator (#12)

### DIFF
--- a/cmd/slang/main.go
+++ b/cmd/slang/main.go
@@ -26,6 +26,14 @@ var (
 	noREPL      = flag.Bool("norepl", false, "Don't start REPL after executing file and string")
 )
 
+type temp struct {
+	Name string
+}
+
+func (temp *temp) Foo() {
+	fmt.Println("foo called")
+}
+
 func main() {
 	flag.Parse()
 

--- a/composites.go
+++ b/composites.go
@@ -11,6 +11,7 @@ import (
 type List struct {
 	Values
 	Position
+
 	special *Fn
 }
 
@@ -24,10 +25,8 @@ func (lf *List) Eval(scope Scope) (Value, error) {
 		return lf.special.Invoke(scope, lf.Values[1:]...)
 	}
 
-	if err := lf.parse(scope); err == nil {
-		if lf.special != nil {
-			return lf.special.Invoke(scope, lf.Values[1:]...)
-		}
+	if err := lf.parse(scope); err == nil && lf.special != nil {
+		return lf.special.Invoke(scope, lf.Values[1:]...)
 	}
 
 	target, err := Eval(scope, lf.Values[0])

--- a/reflect.go
+++ b/reflect.go
@@ -12,7 +12,8 @@ var scopeType = reflect.TypeOf((*Scope)(nil)).Elem()
 // like string, rune, int, float are converted to the right sabre Value
 // types. Functions are converted to the wrapper Fn type. Value of type
 // 'reflect.Type' will be wrapped as 'Type' which enables initializing
-// a value of that type when invoked.
+// a value of that type when invoked. All other types will be wrapped
+// using 'Any' type.
 func ValueOf(v interface{}) Value {
 	if v == nil {
 		return Nil{}
@@ -298,7 +299,11 @@ func isAssignable(from, to reflect.Type) bool {
 func reflectValues(args []Value) []reflect.Value {
 	var rvs []reflect.Value
 	for _, arg := range args {
-		rvs = append(rvs, reflect.ValueOf(arg))
+		if any, ok := arg.(Any); ok {
+			rvs = append(rvs, any.R)
+		} else {
+			rvs = append(rvs, reflect.ValueOf(arg))
+		}
 	}
 	return rvs
 }

--- a/slang/slang.go
+++ b/slang/slang.go
@@ -70,7 +70,7 @@ func (slang *Slang) Bind(symbol string, v sabre.Value) error {
 	}
 
 	if slang.checkNS && nsSym.NS != slang.currentNS {
-		return fmt.Errorf("cannot to bind outside current namespace")
+		return fmt.Errorf("cannot bind outside current namespace")
 	}
 
 	slang.bindings[*nsSym] = v
@@ -199,6 +199,9 @@ func BindAll(scope sabre.Scope) error {
 		"core/let*":         sabre.Let,
 		"core/quote":        sabre.SimpleQuote,
 		"core/syntax-quote": sabre.SyntaxQuote,
+		"core/.": &sabre.Fn{
+			Func: sabre.Dot,
+		},
 
 		"core/eval":      sabre.ValueOf(sabre.Eval),
 		"core/type":      sabre.ValueOf(TypeOf),

--- a/specials.go
+++ b/specials.go
@@ -61,6 +61,46 @@ var (
 	}
 )
 
+// Dot operator provides a way to access members of an object exposed into
+// sabre scope using (. member-name object) form.
+func Dot(scope Scope, args []Value) (Value, error) {
+	if err := verifyArgCount([]int{2}, args); err != nil {
+		return nil, err
+	}
+
+	target, err := Eval(scope, args[1])
+	if err != nil {
+		return nil, err
+	}
+
+	member, ok := args[0].(Symbol)
+	if !ok {
+		return nil, fmt.Errorf("first argument must be symbol, not '%s'",
+			reflect.TypeOf(args[0]))
+	}
+	name := member.Value
+
+	rv := reflect.ValueOf(target)
+	if any, ok := target.(Any); ok {
+		rv = any.R
+	}
+
+	if _, found := rv.Type().MethodByName(name); found {
+		return ValueOf(rv.MethodByName(name).Interface()), nil
+	}
+
+	if rv.Kind() == reflect.Ptr {
+		rv = rv.Elem()
+	}
+
+	if _, found := rv.Type().FieldByName(name); found {
+		return ValueOf(rv.FieldByName(name).Interface()), nil
+	}
+
+	return nil, fmt.Errorf("value of type '%s' has no member named '%s'",
+		rv.Type(), member)
+}
+
 func fnParser(isMacro bool) func(scope Scope, forms []Value) (*Fn, error) {
 	return func(scope Scope, forms []Value) (*Fn, error) {
 		if len(forms) < 1 {


### PR DESCRIPTION
Exposes a new `sabre.Dot` special function that allows accessing member field/method of a type exposed into Scope.

Refer <https://github.com/spy16/sabre/blob/member-access/specials_test.go#L54> for samples.