### PR TITLE
Add Reader options

### DIFF
--- a/reader/options.go
+++ b/reader/options.go
@@ -1,0 +1,65 @@
+package reader
+
+import "github.com/spy16/sabre/runtime"
+
+// Option for Reader
+type Option func(*Reader)
+
+// MacroTable is a lookup table that maps the first rune of a macro expression to its
+// implementation.
+type MacroTable map[rune]Macro
+
+// WithMacros sets the macro table for the reader
+func WithMacros(t MacroTable) Option {
+	if t == nil {
+		t = MacroTable{
+			'"':  readString,
+			';':  readComment,
+			':':  readKeyword,
+			'\\': readCharacter,
+			'(':  readList,
+			')':  UnmatchedDelimiter(),
+			'\'': quoteFormReader("quote"),
+			'~':  quoteFormReader("unquote"),
+			'`':  quoteFormReader("syntax-quote"),
+		}
+	}
+
+	return func(r *Reader) {
+		r.macros = t
+	}
+}
+
+// WithDispatch sets the dispatch table for the reader
+func WithDispatch(t MacroTable) Option {
+	if t == nil {
+		t = MacroTable{}
+	}
+
+	return func(r *Reader) {
+		r.dispatch = t
+	}
+}
+
+// WithPredefinedSymbols maps a set of symbols to a set of values globally.
+func WithPredefinedSymbols(ss map[string]runtime.Value) Option {
+	if ss == nil {
+		ss = map[string]runtime.Value{
+			"nil":   runtime.Nil{},
+			"true":  runtime.Bool(true),
+			"false": runtime.Bool(false),
+		}
+	}
+
+	return func(r *Reader) {
+		r.predef = ss
+	}
+}
+
+func withDefaults(opt []Option) []Option {
+	return append([]Option{
+		WithMacros(nil),
+		WithDispatch(nil),
+		WithPredefinedSymbols(nil),
+	}, opt...)
+}

--- a/repl/options.go
+++ b/repl/options.go
@@ -85,7 +85,9 @@ func WithPrompts(oneLine, multiLine string) Option {
 // Reader. This is useful when you want REPL to use custom reader instance.
 func WithReaderFactory(factory ReaderFactory) Option {
 	if factory == nil {
-		factory = ReaderFactoryFunc(reader.New)
+		factory = ReaderFactoryFunc(func(r io.Reader) *reader.Reader {
+			return reader.New(r)
+		})
 	}
 
 	return func(repl *REPL) {


### PR DESCRIPTION
As part of [Wetware](http://github.com/wetware/ww), the need has arisen reimplement virtually every atom.  Accordingly, I also need to adjust the map of predefined symbols to reflect my own implementation of `Nil`, and `Bool`.

This PR implements the `Option` type for `reader.Reader`.  Currently, options exist to configure:

- the macro table
- the dispatch table
- predefined symbols

⏱️ Estimated review time:  < 10 minutes
✅ Merge when ready