### PR TITLE
Add basic support for recur

### DIFF
--- a/examples/recur/main.go
+++ b/examples/recur/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spy16/sabre"
+)
+
+const rangeTco = `
+(def range (fn* range [min max coll]
+                 (if (= min max)
+                   coll
+                   (recur (inc min) max (coll.Conj min)))))
+
+(print (range 0 10 '()))
+(range 0 1000 '())
+`
+
+const rangeNotTco = `
+(def range (fn* range [min max coll]
+                 (if (= min max)
+                   coll
+                   (range (inc min) max (coll.Conj min)))))
+
+(print (range 0 10 '()))
+(range 0 1000 '())
+`
+
+func main() {
+	scope := sabre.New()
+	scope.BindGo("inc", inc)
+	scope.BindGo("print", fmt.Println)
+	scope.BindGo("=", sabre.Compare)
+
+	initial := time.Now()
+	_, err := sabre.ReadEvalStr(scope, rangeNotTco)
+	if err != nil {
+		panic(err)
+	}
+	final := time.Since(initial)
+	fmt.Printf("no recur: %s\n", final)
+
+	initial = time.Now()
+	_, err = sabre.ReadEvalStr(scope, rangeTco)
+	if err != nil {
+		panic(err)
+	}
+	final = time.Since(initial)
+	fmt.Printf("recur: %s\n", final)
+}
+
+func inc(val sabre.Int64) sabre.Int64 {
+	return val + 1
+}

--- a/func.go
+++ b/func.go
@@ -69,7 +69,37 @@ func (multiFn MultiFn) Invoke(scope Scope, args ...Value) (Value, error) {
 		return nil, err
 	}
 
-	return fn.Invoke(scope, argVals...)
+	result, err := fn.Invoke(scope, argVals...)
+
+	if !isRecur(result) {
+		return result, err
+	}
+
+	for isRecur(result) {
+		args = result.(*List).Values[1:]
+		result, err = fn.Invoke(scope, args...)
+	}
+
+	return result, err
+}
+
+func isRecur(value Value) bool {
+
+	list, ok := value.(*List)
+	if !ok {
+		return false
+	}
+
+	sym, ok := list.First().(Symbol)
+	if !ok {
+		return false
+	}
+
+	if sym.Value != "recur" {
+		return false
+	}
+
+	return true
 }
 
 // Expand executes the macro body and returns the result of the expansion.

--- a/scope.go
+++ b/scope.go
@@ -32,6 +32,7 @@ func New() *MapScope {
 	scope.Bind("if", If)
 	scope.Bind("do", Do)
 	scope.Bind("def", Def)
+	scope.Bind("recur", Recur)
 
 	return scope
 }

--- a/specials.go
+++ b/specials.go
@@ -59,6 +59,11 @@ var (
 		Name:  "syntax-quote",
 		Parse: parseSyntaxQuote,
 	}
+
+	Recur = SpecialForm{
+		Name: "recur",
+		Parse: parseRecur,
+	}
 )
 
 func fnParser(isMacro bool) func(scope Scope, forms []Value) (*Fn, error) {
@@ -255,6 +260,25 @@ func parseSyntaxQuote(scope Scope, forms []Value) (*Fn, error) {
 	return &Fn{
 		Func: func(scope Scope, _ []Value) (Value, error) {
 			return recursiveQuote(scope, forms[0])
+		},
+	}, nil
+}
+
+func parseRecur(scope Scope, forms []Value) (*Fn, error) {
+
+	return &Fn{
+		Func: func(scope Scope, args []Value) (Value, error) {
+			symbol := Symbol{
+				Value: "recur",
+			}
+
+			results, err := evalValueList(scope, args)
+			if err != nil {
+				return nil, err
+			}
+
+			results = append([]Value{symbol}, results...)
+			return &List{Values: results}, nil
 		},
 	}, nil
 }


### PR DESCRIPTION
Hi guys, I've added a basic support for `recur` which will optimize function to create tail-call optimization. 
```go
package main

import (
	"fmt"
	"time"

	"github.com/spy16/sabre"
)

const rangeTco = `
(def range (fn* range [min max coll]
                 (if (= min max)
                   coll
                   (recur (inc min) max (coll.Conj min)))))

(print (range 0 10 '()))
(range 0 1000 '())
`

const rangeNotTco = `
(def range (fn* range [min max coll]
                 (if (= min max)
                   coll
                   (range (inc min) max (coll.Conj min)))))

(print (range 0 10 '()))
(range 0 1000 '())
`

func main() {
	scope := sabre.New()
	scope.BindGo("inc", inc)
	scope.BindGo("print", fmt.Println)
	scope.BindGo("=", sabre.Compare)

	initial := time.Now()
	_, err := sabre.ReadEvalStr(scope, rangeNotTco)
	if err != nil {
		panic(err)
	}
	final := time.Since(initial)
	fmt.Printf("no recur: %s\n", final)

	initial = time.Now()
	_, err = sabre.ReadEvalStr(scope, rangeTco)
	if err != nil {
		panic(err)
	}
	final = time.Since(initial)
	fmt.Printf("recur: %s\n", final)
}

func inc(val sabre.Int64) sabre.Int64 {
	return val + 1
}
```
result:
```sh
$ go run main.go
(0 1 2 3 4 5 6 7 8 9)
no recur: 319.056393ms
(0 1 2 3 4 5 6 7 8 9)
recur: 14.510449ms
```